### PR TITLE
Backfill missing lab metadata (5 files)

### DIFF
--- a/Instructions/Labs/01-configure-auto-failover-groups.md
+++ b/Instructions/Labs/01-configure-auto-failover-groups.md
@@ -1,7 +1,14 @@
 ---
 lab:
-    title: 'Enable application resilience with auto-failover groups for Azure SQL Database'
-    module: 'Get started with Azure SQL Database for cloud-native application development'
+  title: Enable application resilience with auto-failover groups for Azure SQL Database
+  module: Get started with Azure SQL Database for cloud-native application development
+  description: In this exercise you’ll create two Azure SQL databases that will act as primary and secondary. You'll configure auto-failover groups to ensure high availability and disaster recovery of your application databases, and validate the replication status on your application.
+  duration: 30 minutes
+  level: 300
+  islab: true
+  primarytopics:
+    - Azure
+    - Azure SQL Database
 ---
 
 # Enable application resilience with auto-failover groups for Azure SQL Database

--- a/Instructions/Labs/02-deploy-pipelines-sql-database.md
+++ b/Instructions/Labs/02-deploy-pipelines-sql-database.md
@@ -1,7 +1,17 @@
 ---
 lab:
-    title: 'Configure and Deploy CI/CD Pipelines for Azure SQL Database Projects'
-    module: 'Develop for an Azure SQL Database'
+  title: Configure and Deploy CI/CD Pipelines for Azure SQL Database Projects
+  module: Develop for an Azure SQL Database
+  description: In this exercise you'll create, configure, and deploy CI/CD pipelines for Azure SQL Database projects using Visual Studio Code and GitHub Actions. This allows you to familiarize yourself with the process of setting up CI/CD pipelines for Azure SQL Database projects.
+  duration: 30 minutes
+  level: 500
+  islab: true
+  primarytopics:
+    - Azure
+    - Azure SQL Database
+    - GitHub
+    - Visual Studio
+    - Visual Studio Code
 ---
 
 # Configure and deploy CI/CD pipelines for Azure SQL Database projects

--- a/Instructions/Labs/03-develop-data-api-azure-sql-database.md
+++ b/Instructions/Labs/03-develop-data-api-azure-sql-database.md
@@ -3,7 +3,7 @@ lab:
   title: Develop a Data API for Azure SQL Database
   module: Develop a Data API for Azure SQL Database
   description: In this exercise, you will develop and deploy a data API for an Azure SQL Database using Azure Static Web Apps. This will provide hands-on experience in setting up a Data API Builder configuration and deploying it within an Azure Static Web App environment.
-  duration: 118 minutes
+  duration: 45 minutes
   level: 300
   islab: true
   primarytopics:

--- a/Instructions/Labs/03-develop-data-api-azure-sql-database.md
+++ b/Instructions/Labs/03-develop-data-api-azure-sql-database.md
@@ -1,7 +1,15 @@
 ---
 lab:
-    title: 'Develop a Data API for Azure SQL Database'
-    module: 'Develop a Data API for Azure SQL Database'
+  title: Develop a Data API for Azure SQL Database
+  module: Develop a Data API for Azure SQL Database
+  description: In this exercise, you will develop and deploy a data API for an Azure SQL Database using Azure Static Web Apps. This will provide hands-on experience in setting up a Data API Builder configuration and deploying it within an Azure Static Web App environment.
+  duration: 118 minutes
+  level: 300
+  islab: true
+  primarytopics:
+    - Azure
+    - Azure SQL Database
+    - Azure Static Web Apps
 ---
 
 # Develop a Data API for Azure SQL Database

--- a/Instructions/Labs/04-import-export-data.md
+++ b/Instructions/Labs/04-import-export-data.md
@@ -1,7 +1,15 @@
 ---
-lab:  
-    title: 'Import and export data for development in Azure SQL Database'  
-    module: 'Import and export data for development in Azure SQL Database'  
+lab:
+  title: Import and export data for development in Azure SQL Database
+  module: Import and export data for development in Azure SQL Database
+  description: In this exercise, you will import data from an external REST endpoint (simulated using Azure Static Web App) and export data using an Azure Function. The lab will provide practical experience in working with Azure SQL Database for development purposes, focusing on integrating REST APIs and Azure Functions to handle data import/export operations.
+  duration: 158 minutes
+  level: 400
+  islab: true
+  primarytopics:
+    - Azure
+    - Azure Functions
+    - Azure SQL Database
 ---
 
 # Import and export data for development in Azure SQL Database

--- a/Instructions/Labs/04-import-export-data.md
+++ b/Instructions/Labs/04-import-export-data.md
@@ -3,7 +3,7 @@ lab:
   title: Import and export data for development in Azure SQL Database
   module: Import and export data for development in Azure SQL Database
   description: In this exercise, you will import data from an external REST endpoint (simulated using Azure Static Web App) and export data using an Azure Function. The lab will provide practical experience in working with Azure SQL Database for development purposes, focusing on integrating REST APIs and Azure Functions to handle data import/export operations.
-  duration: 158 minutes
+  duration: 45 minutes
   level: 400
   islab: true
   primarytopics:

--- a/Instructions/Labs/05-configure-managed-identity.md
+++ b/Instructions/Labs/05-configure-managed-identity.md
@@ -1,7 +1,16 @@
 ---
 lab:
-    title: 'Configure managed identity for Azure SQL Database'
-    module: 'Explore Azure SQL Database safety practices for development'
+  title: Configure managed identity for Azure SQL Database
+  module: Explore Azure SQL Database safety practices for development
+  description: Next, you'll add your account access to the database. This is needed because only accounts authenticated through Microsoft Entra can create other Microsoft Entra ID users which are a prerequisite for the subsequent steps in this exercise.
+  duration: 30 minutes
+  level: 300
+  islab: true
+  primarytopics:
+    - Azure
+    - Azure SQL Database
+    - Microsoft Entra
+    - Microsoft Entra ID
 ---
 
 # Configure managed identity for Azure SQL Database


### PR DESCRIPTION
This PR backfills missing lab metadata in markdown files.

Rules used:
- Add-only (does not overwrite existing metadata keys)
- Keys: lab.title, lab.description, lab.duration, lab.level, lab.islab
- Optional casing normalization to lowercase when enabled

Files changed: 5

- `Instructions/Labs/01-configure-auto-failover-groups.md` (description,duration,level,islab,primarytopics)
- `Instructions/Labs/02-deploy-pipelines-sql-database.md` (description,duration,level,islab,primarytopics)
- `Instructions/Labs/03-develop-data-api-azure-sql-database.md` (description,duration,level,islab,primarytopics)
- `Instructions/Labs/04-import-export-data.md` (description,duration,level,islab,primarytopics)
- `Instructions/Labs/05-configure-managed-identity.md` (description,duration,level,islab,primarytopics)
